### PR TITLE
Set PHP minimum version to 7.4.

### DIFF
--- a/Controller/DashboardController.php
+++ b/Controller/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Xact\OPCacheDashboard\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/DependencyInjection/XactOPCacheDashboardExtension.php
+++ b/DependencyInjection/XactOPCacheDashboardExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Xact\OPCacheDashboard\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -13,7 +15,6 @@ class XactOPCacheDashboardExtension extends Extension implements PrependExtensio
      * Load the DI configuration
      *
      * @param mixed[] $configs
-     *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
      */
     public function load(array $configs, ContainerBuilder $container): void

--- a/Tests/ControllerTest.php
+++ b/Tests/ControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Xact\OPCacheDashboard\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -7,44 +9,28 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 class ControllerTest extends WebTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
-     * @var \Xact\CommandScheduler\Scheduler\CommandScheduler
-     */
-    private $scheduler;
-
-    /**
-     *
-     * @var \Symfony\Bundle\FrameworkBundle\Client
-     */
-    private $client;
-
-    protected static function getKernelClass()
-    {
-        return TestKernel::class;
-    }
-
-    /**
      * N.B. The functional controller tests currently do nothing until we can resolve the following errors:
      * [critical] Uncaught PHP Exception LogicException: ""Xact\OPCacheDashboard\Controller\DashboardController"
      *   has no container set, did you forget to define it as a service subscriber?" at
      *   /var/projects/command-scheduler/vendor/symfony/framework-bundle/Controller/ControllerResolver.php line 39
-     * 
+     *
      * This is happening on ALL the controller tests
      */
 
     /**
      * @group controller
      */
-    public function testDashboard()
+    public function testDashboard(): void
     {
         /*
         $this->client->request('GET', '/opcache-dashboard');
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
         */
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
     }
 }

--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Xact\CommandScheduler\Tests;
 
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
@@ -12,13 +13,17 @@ class TestKernel extends Kernel
 {
     use MicroKernelTrait;
 
+    public function configureContainer(): void
+    {
+    }
+
     /**
      * @inheritDoc
      */
     public function registerBundles()
     {
         $bundles = [
-            \Symfony\Bundle\FrameworkBundle\FrameworkBundle::class,
+            FrameworkBundle::class,
         ];
 
         foreach ($bundles as $class) {
@@ -26,10 +31,9 @@ class TestKernel extends Kernel
         }
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(RouteCollectionBuilder $routes): void
     {
-        $confDir = $this->getProjectDir().'/Resources/config';
-        $routes->import($confDir.'/routing.yaml');
+        $confDir = $this->getProjectDir() . '/Resources/config';
+        $routes->import($confDir . '/routing.yaml');
     }
 }
-

--- a/XactOPCacheDashboard.php
+++ b/XactOPCacheDashboard.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Xact\OPCacheDashboard;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.2.5",
-        "symfony/twig-bundle": "^3.4|^4.4|^5.0|^6.0"
+        "symfony/twig-bundle": "^3.4|^4.4"
     },
     "require-dev": {
         "symfony/debug-pack": "*",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,11 +4,12 @@
 
     <arg name="extensions" value="php,inc" />
     <arg name="colors"/>
+    <arg name="report-width" value="120" />
 
 	<exclude-pattern>vendor/*</exclude-pattern>
 
-    <!-- Check for cross-version support for PHP 7.3 and higher using PHPCompatibility. -->
-    <config name="testVersion" value="7.3-"/>
+    <!-- Check for cross-version support for PHP 7.4 and higher using PHPCompatibility. -->
+    <config name="testVersion" value="7.4"/>
     <rule ref="PHPCompatibility"/>
     
     <rule ref="PSR12">
@@ -22,44 +23,56 @@
         </properties>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
-        <properties>
-            <property name="linesCountBeforeFirstContent" value="0"/>
-            <property name="linesCountBetweenAnnotationsGroups" value="1"/>
-            <property name="linesCountBetweenDescriptionAndAnnotations" value="1"/>
-            <property name="linesCountAfterLastContent" value="0"/>
-            <property name="annotationsGroups" type="array">
-                <element value="
-                    @var,
-                    @param,
-                    @return,
-                "/>
-                <element value="
-                    @ORM\,
-                    @UniqueEntity,
-                    @Assert\,
-                "/>
-                <element value="
-                    @Serializer\,
-                "/>
-                <element value="
-                    @Route,
-                    @ParamConverter,
-                "/>
-            </property>
-        </properties>
-    </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"></rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"></rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"></rule>
-    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"></rule>
-    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"></rule>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
             <property name="searchAnnotations " value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ClassStructure">
+        <properties>
+            <property name="groups" type="array">
+                <element value="uses" />
+                <element value="public constants" />
+                <element value="protected constants" />
+                <element value="private constants" />
+                <element value="public static properties, public properties" />
+                <element value="protected properties, protected static properties, private properties, private static properties" />
+                <element value="static constructors, constructor, destructor " />
+                <element value="magic methods" />
+                <element value="protected static abstract methods, protected abstract methods" />
+                <element value="public static abstract methods, public abstract methods, public methods, public static methods" />
+                <element value="protected methods, protected static methods, private methods, private static methods" />
+            </property>
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectStrictTypesFormat" />
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBetweenOpenTagAndDeclare" />
+        <properties>
+            <property name="declareOnFirstLine" value="false" />
+            <property name="linesCountBeforeDeclare" value="1" />
+            <property name="linesCountAfterDeclare" value="1" />
+        </properties>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"></rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"></rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"></rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"></rule>
+    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"></rule>
+    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue">
+        <properties>
+            <property name="searchAnnotations " value="true"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"></rule>
+    <rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
+        <properties>
+            <property name="linesCountBeforeFirstContent " value="0"/>
+            <property name="linesCountAfterLastContent " value="0"/>
+            <property name="linesCountBetweenDescriptionAndAnnotations " value="1"/>
+            <property name="linesCountBetweenDifferentAnnotationsTypes" value="0"/>
+        </properties>
+    </rule>
 
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
@@ -78,16 +91,6 @@
                 <element key="jpeg2wbmp" value="null"/>
                 <element key="__autoload" value="null"/>
                 <!-- Deprecated Features 7.3, https://secure.php.net/manual/en/migration73.deprecated.php -->
-                <!-- Searching Strings for non-string Needle -->
-                <!--
-                <element key="strpos" value="chr"/>
-                <element key="strrpos" value="chr"/>
-                <element key="stripos" value="chr"/>
-                <element key="strstr" value="chr"/>
-                <element key="stristr" value="chr"/>
-                <element key="strchr" value="chr"/>
-                <element key="strrchr" value="chr"/>
-                -->
                 <!-- Strip-Tags Streaming -->
                 <element key="fgetss" value="fgets"/>
                 <element key="gzgets" value="gzgets"/>


### PR DESCRIPTION
Set PHP minimum version to 7.4
Coding standards set to customised PSR12.
Limit Symfony versions to 4, due to depreciation of RouteCollectionBuilder.