### PR TITLE
Include  Symfony 5.4 releases.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.4",
-        "symfony/twig-bundle": "^3.4|^4.4",
-        "twig/twig": "^2.13|^3.0.4"
+        "symfony/twig-bundle": "^3.4|^4.4|^5.4",
+        "twig/twig": "^2.13|^3.4.3"
     },
     "require-dev": {
         "symfony/debug-pack": "*",


### PR DESCRIPTION
Include  Symfony 5.4 releases. Increase Twig version to avoid security vulnerabilities.